### PR TITLE
Bump GitHub Actions Checkout

### DIFF
--- a/.github/workflows/build-sr2019.yml
+++ b/.github/workflows/build-sr2019.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/build-sr2022.yml
+++ b/.github/workflows/build-sr2022.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/build-sr2023.yml
+++ b/.github/workflows/build-sr2023.yml
@@ -9,7 +9,7 @@ jobs:
   build-2023:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v4


### PR DESCRIPTION
This avoids deprecation of Node 16 which is likely to come soon given that it is now beyond end of life.